### PR TITLE
--only オプション追加

### DIFF
--- a/lib/ec2ctl.rb
+++ b/lib/ec2ctl.rb
@@ -1,4 +1,4 @@
-require "ec2ctl/version"
+#require "lib/ec2ctl/version"
 
 require "thor"
 require "aws-sdk-v1"
@@ -31,6 +31,7 @@ module Ec2ctl
       puts VERSION
     end
 
+    option :only, default: false
     option :sort, default: name, aliases: [:S]
     option :limit, type: :numeric, aliases: [:l]
     desc "list PATTERN", "List all instances in region. Specify PATTERN to filter results by name."
@@ -63,7 +64,11 @@ module Ec2ctl
       rows.sort_by! {|row| row[col].to_s} if col
       rows = rows[0, options[:limit]] if options[:limit]
 
-      puts Terminal::Table.new headings: ["ID", "Name", "Type", "Private IP", "Public IP", "Status"], rows: rows
+      unless options[:only]
+        puts Terminal::Table.new headings: ["ID", "Name", "Type", "Private IP", "Public IP", "Status"], rows: rows
+      else
+        rows.each { |r| puts r[col] }
+      end
     end
 
     desc "status NAME", "Show instance status. Instance will be searched by Name tag."


### PR DESCRIPTION
EC2 リストを取得する際に `--sort` オプションと併用することで、指定するカラムの情報だけを取得するようにしました。

```
% ec2ctl list siege --region=ap-northeast-1 --sort=Private
+------------+-------+----------+--------------+-----------+---------+
| ID         | Name  | Type     | Private IP   | Public IP | Status  |
+------------+-------+----------+--------------+-----------+---------+
| i-xxxxxxxx | siege | c3.large | 172.31.xx.xx |           | stopped |
+------------+-------+----------+--------------+-----------+---------+
```

`--only` オプションを付けると...

```
% ec2ctl list siege --region=ap-northeast-1 --sort=Private --only
172.31.xx.xx
```

御確認の程宜しくお願い致します。